### PR TITLE
build: use codeowners file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,5 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
-[*.yaml]
+[{*.yaml,*.yml,*.md}]
 indent_size = 2

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @rlespinasse

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,21 @@
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
+  - package-ecosystem: 'cargo'
+    directory: '/'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
     groups:
       dependencies:
         patterns:
-          - "*"
-    reviewers:
-      - "rlespinasse"
-    labels: [ ]
-    
-  - package-ecosystem: "github-actions"
-    directory: "/"
+          - '*'
+    labels: []
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
     groups:
       dependencies:
         patterns:
-          - "*"
-    reviewers:
-      - "rlespinasse"
-    labels: [ ]
+          - '*'
+    labels: []

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -33,4 +33,5 @@ jobs:
           VALIDATE_RUST_2021: false
           # edition2024 is not supported yet
           VALIDATE_RUST_CLIPPY: false
+          VALIDATE_YAML_PRETTIER: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/